### PR TITLE
Add celery cmd to automatically find the celery app

### DIFF
--- a/django_toolshed/celery_auto_app.py
+++ b/django_toolshed/celery_auto_app.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+import re
+import subprocess
+import sys
+
+import click
+
+
+@click.command(
+    context_settings=dict(
+        ignore_unknown_options=True, allow_extra_args=True, help_option_names=["--noop"]
+    ),
+)
+@click.argument("celery_args", nargs=-1, type=click.UNPROCESSED)
+def command(celery_args):
+    try:
+        text = subprocess.check_output(grep_cmd(), shell=True, text=True)
+    except subprocess.CalledProcessError as ex:
+        if ex.returncode == 1:
+            click.secho(
+                "Error: Failed to automatically detect a celery app using :"
+                f"cmd=`{grep_cmd()}`",
+                fg="red",
+            )
+            raise click.Abort()
+
+    lines = text.strip().split("\n", maxsplit=1)
+    if len(lines) > 1:
+        click.secho(
+            ("Found multiple Celery apps. Unable to autodetect app. " f"Apps: {lines}"),
+            fg="red",
+        )
+    celery_config_line = lines[0]
+    celery_config_module = (
+        celery_config_line.split(":")[0].replace("/", ".").replace(".py", "")
+    )
+    celery_app_var = re.search(r":(\w+)\s", celery_config_line).group(1)
+    # pylint: disable=subprocess-run-check
+    result = subprocess.run(
+        ["celery", f"--app={celery_config_module}:{celery_app_var}"] + list(celery_args)
+    )
+    sys.exit(result.returncode)
+
+
+def grep_cmd():
+    return "grep -r --exclude-dir='.*' --include='*.py' '= Celery('"
+
+
+if __name__ == "__main__":
+    # pylint: disable=no-value-for-parameter
+    command()

--- a/poetry.lock
+++ b/poetry.lock
@@ -694,8 +694,8 @@ python-versions = "*"
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.9"
-content-hash = "f25c75cbf1b3290ba76e3dfa855c4329304eb4b23bb0eb1022bb5edc19e8de2b"
+python-versions = "^3.8"
+content-hash = "6b3c26cadaa0726829d67d8cbbd3647db8217875132a112c2a399f5ef53af712"
 
 [metadata.files]
 appdirs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,9 @@ description = ""
 authors = ["Dani Hodovic <you@example.com>"]
 license = "MIT"
 
+[tool.poetry.scripts]
+celery-auto-app = "django_toolshed.celery_auto_app:command"
+
 [tool.poetry.dependencies]
 python = "^3.8"
 Django = "^3.1"


### PR DESCRIPTION
Instead of having to provide --app for each celery command to specify
the application config file, use this helper script to detect it.